### PR TITLE
removed matrix check in regularized_eigenvalue_decomposition

### DIFF
--- a/posce/population_shrunk_covariance.py
+++ b/posce/population_shrunk_covariance.py
@@ -37,7 +37,6 @@ def regularized_eigenvalue_decomposition(C, explained_variance_threshold):
     L is the diagonal matrix of the truncated eigenvalues,
     alpha is set such that trace(Cr) = trace(C)
     """
-    _check_spd(C)
     if explained_variance_threshold > 1 or explained_variance_threshold < 0:
         raise ValueError(
             "Threshold of the explained variance eigenvalue"


### PR DESCRIPTION
Hi @mrahim 
I tried to run the examples and ran into issues with the `prior_cov_`matrix not being positively defined.
@GaelVaroquaux  explained that this is happening because of the small sample size, resulting in this matrix not being strictly positive.

I removed the check. What do you think?
